### PR TITLE
Update room ID regex to prepare for v12 rooms

### DIFF
--- a/src/StringlyTypedMatrix/StringRoomID.ts
+++ b/src/StringlyTypedMatrix/StringRoomID.ts
@@ -9,7 +9,7 @@
 
 import { StringServerName } from "./StringServerName";
 
-const StringRoomIDRegex = /^![^:]*:(?<serverName>\S*)/;
+const StringRoomIDRegex = /^!([^:]*:|[a-zA-Z0-9-_]{43})(?<serverName>\S*)/;
 
 export type StringRoomIDBrand = {
   readonly StringRoomID: unique symbol;


### PR DESCRIPTION
Gave a skim over src/MatrixReference/MatrixRoomReference.ts, i don't think anything should break. The main notable behaviour difference here is that the `serverName` group becomes an empty string, which will need to be handled appropriately downstream.